### PR TITLE
生徒詳細にてCA登録可能に実装

### DIFF
--- a/app/assets/stylesheets/advisors/students.scss
+++ b/app/assets/stylesheets/advisors/students.scss
@@ -25,7 +25,7 @@
               border: solid 1px #9a9a9a;
             }
             .ca__my__main__applying__detail__table__tr__th__term{
-              width: 15%;
+              width: 5%;
               background-color: #C34035;
               color:#ffffff;
               text-align: center;
@@ -39,14 +39,14 @@
               border: solid 1px #9a9a9a;
             }
             .ca__my__main__applying__detail__table__tr__th__applying{
-              width: 15%;
+              width: 50%;
               background-color: #C34035;
               color:#ffffff;
               text-align: center;
               border: solid 1px #9a9a9a;
             }
             .ca__my__main__applying__detail__table__tr__th__other{
-              width: 35%;
+              width: 10%;
               background-color: #C34035;
               color:#ffffff;
               text-align: center;
@@ -62,6 +62,9 @@
                 text-decoration: none;
                 color:#2490D0;
                 font-weight: bold;
+              }
+              a:hover{
+                color:#b3d4fc;
               }
             }
             .ca__my__main__applying__detail__table__tr__td__term{
@@ -81,14 +84,17 @@
                 color: #2490D0;
               }
               .ca__my__main__applying__detail__table__tr__td__ca__pic:hover{
+                a{
                 color: #b3d4fc;
                 cursor: pointer;
+                }
               }
             }
             .ca__my__main__applying__detail__table__tr__td__applying{
               background-color: #ffffff;
               padding-left: 5px;
               border: solid 1px #9a9a9a;
+              letter-spacing: 0.1em;
             }
             .ca__my__main__applying__detail__table__tr__td__other{
               background-color: #ffffff;

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -24,6 +24,13 @@ class StudentsController < ApplicationController
   def destroy
   end
 
+  def ca
+    @student = Student.find(params[:id])
+    @student.advisor_id = current_advisor.id
+    @student.save
+    redirect_to students_advisors_path
+  end
+
   private
 
   def student_params

--- a/app/views/advisors/students.html.erb
+++ b/app/views/advisors/students.html.erb
@@ -18,7 +18,7 @@
               担当CA
             </th>
             <th class = "ca__my__main__applying__detail__table__tr__th__applying">
-              応募企業数
+              選考状況（会社数）
             </th>
             <th class = "ca__my__main__applying__detail__table__tr__th__other">
               備考
@@ -35,14 +35,18 @@
               <td class = "ca__my__main__applying__detail__table__tr__td__ca">
                 <span><%= student.advisor.name %></span>
                 <% if student.advisor.id == 1%>
-                  <span class = "ca__my__main__applying__detail__table__tr__td__ca__pic">担当になる</span>
+                  <span class = "ca__my__main__applying__detail__table__tr__td__ca__pic"><%= link_to "担当になる", ca_student_path(id: student.id) %></span>
                 <% end %>
               </td>
               <td class = "ca__my__main__applying__detail__table__tr__td__applying">
-                <%= student.student_jobs.count%>社
+                CAおすすめ：<%= student.student_jobs.where(student_job_state_id: 1).count == 0 ? "- " : student.student_jobs.where(student_job_state_id: 1).count%> → 
+                検討中：<%= student.student_jobs.where(student_job_state_id: 2).count == 0 ? "- " : student.student_jobs.where(student_job_state_id: 2).count%> → 
+                応募中：<%= student.student_jobs.where(student_job_state_id: 3).count == 0 ? "- " : student.student_jobs.where(student_job_state_id: 3).count%> → 
+                選考中：<%= student.student_jobs.where(student_job_state_id: 4).count == 0 ? "- " : student.student_jobs.where(student_job_state_id: 4).count%> → 
+                内定済：<%= student.student_jobs.where(student_job_state_id: 5).count == 0 ? "- " : student.student_jobs.where(student_job_state_id: 5).count%>
               </td>
               <td class = "ca__my__main__applying__detail__table__tr__td__other">
-                
+                <%= student.student_jobs.count%>社
               </td>
             </tr>
           <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,9 @@ Rails.application.routes.draw do
     get 'keep', to: 'jobs#keep', on: :member
     get 'apply', to: 'jobs#apply', on: :member
   end
-  resources :students, only: [:show,:edit,:update,:destroy]
+  resources :students, only: [:show,:edit,:update,:destroy] do
+    get 'ca', to: 'students#ca', on: :member
+  end
   get "advisors/:id" => "advisors#show"  #CAのmy page
 
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -869,40 +869,40 @@ end
 Chat.create(
   comment:"初めまして",
   student_id:1,
-  advisor_id:1,
+  advisor_id:2,
 )
 Chat.create(
   comment:"shoです",
   student_id:1,
-  advisor_id:1,
+  advisor_id:2,
 )
 Chat.create(
   comment:"shoさんこんにちは、半谷です",
   student_id:1,
-  advisor_id:1,
+  advisor_id:2,
 )
 Chat.create(
   comment:"よろしくお願い致します。",
   student_id:1,
-  advisor_id:1,
+  advisor_id:2,
 )
 Chat.create(
   comment:"こんにちは",
   student_id:3,
-  advisor_id:1,
+  advisor_id:2,
 )
 Chat.create(
   comment:"shimpeiです",
   student_id:3,
-  advisor_id:1,
+  advisor_id:2,
 )
 Chat.create(
   comment:"shimpeiさんこんにちは、半谷です",
   student_id:3,
-  advisor_id:1,
+  advisor_id:2,
 )
 Chat.create(
   comment:"さようなら。",
   student_id:3,
-  advisor_id:1,
+  advisor_id:2,
 )


### PR DESCRIPTION
# what
生徒の詳細画面で、まだCAが付いてない生徒には、ログインしているCAが担当になることができる。
ほかのCAを指定することはできない。

# why
最初登録された生徒はCAを自分で登録するのではなく、CA側で担当を決めることになるため