### PR TITLE
job_imageテーブル追加

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -14,4 +14,5 @@ class Job < ApplicationRecord
   has_many :various_allowances, through: :various_allowance_jobs
   has_many :various_insurance_jobs
   has_many :various_insurances, through: :various_insurance_jobs
+  has_many :job_images
 end

--- a/app/models/job_image.rb
+++ b/app/models/job_image.rb
@@ -1,0 +1,3 @@
+class JobImage < ApplicationRecord
+  belongs_to :job
+end

--- a/db/migrate/20190722083552_create_job_images.rb
+++ b/db/migrate/20190722083552_create_job_images.rb
@@ -1,0 +1,9 @@
+class CreateJobImages < ActiveRecord::Migration[5.2]
+  def change
+    create_table :job_images do |t|
+      t.references :job, null: false, foreign_key: true
+      t.string :url, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_19_045735) do
+ActiveRecord::Schema.define(version: 2019_07_22_083552) do
 
   create_table "advisors", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -60,6 +60,14 @@ ActiveRecord::Schema.define(version: 2019_07_19_045735) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name"
+  end
+
+  create_table "job_images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "url", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["job_id"], name: "index_job_images_on_job_id"
   end
 
   create_table "job_states", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -230,5 +238,6 @@ ActiveRecord::Schema.define(version: 2019_07_19_045735) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "job_images", "jobs"
   add_foreign_key "students", "advisors"
 end

--- a/test/fixtures/job_images.yml
+++ b/test/fixtures/job_images.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/job_image_test.rb
+++ b/test/models/job_image_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class JobImageTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# what
job_imageテーブル追加により、求人に画像をもたせる。
求人は複数の画像を持つことができる。