### PR TITLE
求人詳細にて募集中と募集終了を変更できる

### DIFF
--- a/app/assets/stylesheets/jobs/show.scss
+++ b/app/assets/stylesheets/jobs/show.scss
@@ -53,6 +53,23 @@
       font-size: 0.8rem;
       cursor: pointer;
     }
+    .job__main__detail__state{
+      float: right;
+      font-size: 0.8rem;
+      padding: 3px;
+      background-color: yellow;
+      border: solid 1px #9a9a9a;
+      cursor: pointer;
+      .job__main__detail__state__change{
+        a{
+          text-decoration: none;
+          color: #000000;
+        }
+        a:hover{
+          color: red;
+        }
+      }
+    }
     .job__main__detail__apply{
       float:right;
       a{

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -72,6 +72,17 @@ class JobsController < ApplicationController
     redirect_to job_path(id: params[:id])
   end
 
+  def state
+    @new_job_state = Job.find_by(id: params[:id])
+    if @new_job_state.job_state_id == 1
+      @new_job_state.job_state_id = 2
+    else
+      @new_job_state.job_state_id = 1
+    end
+    @new_job_state.save
+    redirect_to job_path(id: params[:id])
+  end
+
   private
 
   def job_params

--- a/app/views/jobs/show.html.erb
+++ b/app/views/jobs/show.html.erb
@@ -2,7 +2,7 @@
   <div class = "job__main__detail">
     <!-- タイトル -->
     <div class = "job__main__detail__title">
-      <%= @job.name%> / <%= @job.position %> 募集終了にするを加える
+      <%= @job.name%> / <%= @job.position %> 
       <% if @job.job_state_id == 2%>
         <span>※募集終了</span>
       <% end %>
@@ -73,6 +73,15 @@
           });
       });
     </script>
+    <% if advisor_signed_in?%>
+      <div class = "job__main__detail__state">
+        <% if @job.job_state_id == 1%>
+          <span class = "job__main__detail__state__change"><%= link_to "募集終了にする", state_job_path(id: @job.id)%></span>
+        <% else %>
+          <span class = "job__main__detail__state__change"><%= link_to "募集再開する", state_job_path(id: @job.id)%></span>
+        <% end %>
+      </div>
+    <% end %>
     <!-- 生徒でログイン時、もし未応募なら応募できる -->
     <% if student_signed_in?%>
       <% if @state.student_job_state.id <= 2 && @job.job_state_id == 1%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
     get 'keep', to: 'jobs#keep', on: :member     #jobの選考状況を検討中へ変更(生徒のmyページにて)
     get 'apply', to: 'jobs#apply', on: :member   #jobの選考状況を応募へ変更(生徒のmyページにて)
     get 'change', to: 'jobs#change', on: :member #jobの選考状況を変更(求人詳細にて)
+    get 'state', to: 'jobs#state', on: :member   #jobの応募状況を変更(求人詳細にて)
   end
   resources :students, only: [:show,:edit,:update,:destroy] do
     get 'ca', to: 'students#ca', on: :member     #CAが未登録の場合、自分がCAになる


### PR DESCRIPTION
# what
求人の詳細ページで、その求人が募集中の時、CAが募集終了にできる。
また、すでに求人が募集終了の時、CAが募集再開にできる

# why
求人が終わり次第、募集終了にする必要があるため。
また、終了したが再開する求人がある可能性があるため