### PR TITLE
生徒マイページにてCA推薦中と検討中の変更を可能にした

### DIFF
--- a/app/assets/stylesheets/students/show.scss
+++ b/app/assets/stylesheets/students/show.scss
@@ -282,6 +282,7 @@
                 background-color: gray;
                 padding: 3px;
                 border-radius: 5px;
+                letter-spacing: 0.7em;
               }
               .st__my__main__keepca__detail__table__tr__td__action__recommend{
                 float:left;

--- a/app/controllers/chats_controller.rb
+++ b/app/controllers/chats_controller.rb
@@ -1,10 +1,10 @@
 class ChatsController < ApplicationController
 
   def index
-    @jobs = Job.all
+    @jobs = Job.all()
     @newjobs = Job.all.order(id: "DESC")
     @chats = Chat.new
-    @images = JobImage.all
+    @images = JobImage.all()
   end
 
   def new

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -57,7 +57,29 @@ class JobsController < ApplicationController
   def apply                                                                                     #jobsコントローラーのkeepアクションは、キープ中となっている選考状況を応募に進める操作を行っている
     if student_signed_in?                                                                       #生徒でログインしている時に、自分の選考状況を操作可能
       @new_state = StudentJob.find_by(student_id: current_student.id, job_id: params[:id])      #student_jobテーブルの内、student_idがログイン中のユーザーidで、かつjob_idは現在指定したjob_idをいれt、1つのレコードを取得
-      @new_state.student_job_state_id = 3                                                       #キープ中のidが2で、その1つ次、つまりid = 3を代入している
+      @new_state.student_job_state_id = 3                                                       #id = 3を代入している
+      @new_state.save                                                                           #student_job_state_idが3に変更されたものを保存している
+      redirect_to student_path(id: current_student.id)                                          #元のページに戻る
+    else                                                                                        #仮にCAでログインしている場合、勝手に生徒の選考状況を変更するわけに行かないので、トップページに戻る
+      redirect_to root_path
+    end
+  end
+
+  def consider                                                                                     #jobsコントローラーのkeepアクションは、キープ中となっている選考状況を応募に進める操作を行っている
+    if student_signed_in?                                                                       #生徒でログインしている時に、自分の選考状況を操作可能
+      @new_state = StudentJob.find_by(student_id: current_student.id, job_id: params[:id])      #student_jobテーブルの内、student_idがログイン中のユーザーidで、かつjob_idは現在指定したjob_idをいれt、1つのレコードを取得
+      @new_state.student_job_state_id = 2                                                       #id = 2を代入している
+      @new_state.save                                                                           #student_job_state_idが3に変更されたものを保存している
+      redirect_to student_path(id: current_student.id)                                          #元のページに戻る
+    else                                                                                        #仮にCAでログインしている場合、勝手に生徒の選考状況を変更するわけに行かないので、トップページに戻る
+      redirect_to root_path
+    end
+  end
+
+  def decline                                                                                     #jobsコントローラーのkeepアクションは、キープ中となっている選考状況を応募に進める操作を行っている
+    if student_signed_in?                                                                       #生徒でログインしている時に、自分の選考状況を操作可能
+      @new_state = StudentJob.find_by(student_id: current_student.id, job_id: params[:id])      #student_jobテーブルの内、student_idがログイン中のユーザーidで、かつjob_idは現在指定したjob_idをいれt、1つのレコードを取得
+      @new_state.student_job_state_id = 7                                                       #id = 7を代入している
       @new_state.save                                                                           #student_job_state_idが3に変更されたものを保存している
       redirect_to student_path(id: current_student.id)                                          #元のページに戻る
     else                                                                                        #仮にCAでログインしている場合、勝手に生徒の選考状況を変更するわけに行かないので、トップページに戻る

--- a/app/views/chats/index.html.erb
+++ b/app/views/chats/index.html.erb
@@ -6,9 +6,9 @@
         <% @jobs.each do |job| %>
         <div class="jobIndex__inner__left__wrapper__content">
           <% if student_signed_in? || advisor_signed_in?%>
-          <%= link_to link_to job_path(id: job.id), class: "jobIndex__inner__left__wrapper__content__imgLink" do %>
+          <%= link_to job_path(id: job.id), class: "jobIndex__inner__left__wrapper__content__imgLink" do %>
             <div class="jobIndex__inner__left__wrapper__content__imgLink__box">
-              <%= image_tag 'photo4.png',width: '250',height: '180', class: "jobIndex__inner__left__wrapper__content__imgLink__img" %>
+              <%= image_tag @images.find_by(job_id: 2).url, width: '250',height: '180', class: "jobIndex__inner__left__wrapper__content__imgLink__img" %>
             </div>
           <% end %>
           <%else%>

--- a/app/views/students/show.html.erb
+++ b/app/views/students/show.html.erb
@@ -75,7 +75,6 @@
       <div class = "st__my__main__keepca__title">
         検討中の企業一覧
       </div>
-
       <!-- テーブルのカラム名 -->
       <table class = "st__my__main__keepca__table">
         <tr class = "st__my__main__keepca__table__tr">
@@ -130,11 +129,11 @@
                         <%=  "終了" %>
                       </div>
                     <% end %>
-                    <div class = "st__my__main__keepca__detail__table__tr__td__action__detail">
+                    <%# <div class = "st__my__main__keepca__detail__table__tr__td__action__detail">
                       <%= link_to  "詳細", "/jobs/#{job.job.id}"  %>
-                    </div>
+                    <%# </div> %>
                     <div class = "st__my__main__keepca__detail__table__tr__td__action__remove">
-                      <%= link_to "削除", keep_job_path(id: job.job.id) %>
+                      <%= link_to "検討中止", keep_job_path(id: job.job.id) %>
                     </div>
                   <% else %> <span class = "st__my__main__keepca__detail__table__tr__td__action__ca">生徒のみ表示</span>
                   <% end %>
@@ -146,70 +145,80 @@
       </div>
     </section>
 
-    <!-- 未応募の企業一覧（CAのみ閲覧可能） -->
-    <% if advisor_signed_in? %>
-      <section class = "st__my__main__keepca">
-        <div class = "st__my__main__keepca__title">
-          その他企業
-        </div>
+    <!-- CA推薦中の企業一覧（） -->
+    <section class = "st__my__main__keepca">
+      <div class = "st__my__main__keepca__title">
+        CA推薦中の企業一覧
+      </div>
 
-        <!-- テーブルのカラム名 -->
-        <table class = "st__my__main__keepca__table">
-          <tr class = "st__my__main__keepca__table__tr">
-            <th class = "st__my__main__keepca__table__tr__th__name">
-              企業名
-            </th>
-            <th class = "st__my__main__keepca__table__tr__th__position">
-              ポジション
-            </th>
-            <th class = "st__my__main__keepca__table__tr__th__salary">
-              年収
-            </th>
-            <th class = "st__my__main__keepca__table__tr__th__location">
-              勤務地
-            </th>
-            <th class = "st__my__main__keepca__table__tr__th__action">
-              アクション
-            </th>
-          </tr>
-        </table>
+      <!-- テーブルのカラム名 -->
+      <table class = "st__my__main__keepca__table">
+        <tr class = "st__my__main__keepca__table__tr">
+          <th class = "st__my__main__keepca__table__tr__th__name">
+            企業名
+          </th>
+          <th class = "st__my__main__keepca__table__tr__th__position">
+            ポジション
+          </th>
+          <th class = "st__my__main__keepca__table__tr__th__salary">
+            年収
+          </th>
+          <th class = "st__my__main__keepca__table__tr__th__location">
+            勤務地
+          </th>
+          <th class = "st__my__main__keepca__table__tr__th__action">
+            アクション
+          </th>
+        </tr>
+      </table>
 
-        <!-- 求人の詳細情報やアクション選択 -->
-        <div class = "st__my__main__keepca__detail">
-          <table class = "st__my__main__keepca__detail__table">
-            <% @job_state.each do |job| %>
-              <% if job.student_job_state.id == 2%>
-                <tr class = "st__my__main__keepca__detail__table__tr">
-                  <td class = "st__my__main__keepca__detail__table__tr__td__name">
-                    <%= link_to  job.job.name, "/jobs/#{job.job.id}"  %>
-                  </td>
-                  <td class = "st__my__main__keepca__detail__table__tr__td__position">
-                    <%= job.job.position %>
-                  </td>
-                  <td class = "st__my__main__keepca__detail__table__tr__td__salary">
-                    <% if job.job.min_annual_income == job.job.max_annual_income%>
-                      <%= job.job.min_annual_income %>万
-                    <% else %>
-                      <%= job.job.min_annual_income %>万 〜 <%= job.job.max_annual_income %>万
-                    <% end %>
-                  </td>
-                  <td class = "st__my__main__keepca__detail__table__tr__td__location">
-                    <%= job.job.location.prefecture %>
-                  </td>
-                  <td class = "st__my__main__keepca__detail__table__tr__td__action">
-                    <div class = "st__my__main__keepca__detail__table__tr__td__action__recommend">
-                      <%= link_to "勧める", apply_job_path(id: job.job.id) %>
+      <!-- 求人の詳細情報やアクション選択 -->
+      <div class = "st__my__main__keepca__detail">
+        <table class = "st__my__main__keepca__detail__table">
+          <% @job_state.each do |job| %>
+            <% if job.student_job_state.id == 1%>
+              <tr class = "st__my__main__keepca__detail__table__tr">
+                <td class = "st__my__main__keepca__detail__table__tr__td__name">
+                  <%= link_to  job.job.name, "/jobs/#{job.job.id}"  %>
+                </td>
+                <td class = "st__my__main__keepca__detail__table__tr__td__position">
+                  <%= job.job.position %>
+                </td>
+                <td class = "st__my__main__keepca__detail__table__tr__td__salary">
+                  <% if job.job.min_annual_income == job.job.max_annual_income%>
+                    <%= job.job.min_annual_income %>万
+                  <% else %>
+                    <%= job.job.min_annual_income %>万 〜 <%= job.job.max_annual_income %>万
+                  <% end %>
+                </td>
+                <td class = "st__my__main__keepca__detail__table__tr__td__location">
+                  <%= job.job.location.prefecture %>
+                </td>
+                <td class = "st__my__main__keepca__detail__table__tr__td__action">
+                <% if student_signed_in? %>
+                  <% if job.job.job_state_id == 1%>
+                    <div class = "st__my__main__keepca__detail__table__tr__td__action__apply">
+                      <%= link_to "応募", apply_job_path(id: job.job.id) %>
                     </div>
-                    <div class = "st__my__main__keepca__detail__table__tr__td__action__recommended">
-                      お勧め済
+                  <% else %>
+                    <div class = "st__my__main__keepca__detail__table__tr__td__action__apply__ng">
+                      <%=  "終了" %>
                     </div>
-                  </td>
-                </tr>
-              <% end %>
+                  <% end %>
+                  <div class = "st__my__main__keepca__detail__table__tr__td__action__detail">
+                    <%= link_to  "検討", consider_job_path(id: job.job.id)  %>
+                  </div>
+                  <div class = "st__my__main__keepca__detail__table__tr__td__action__remove">
+                    <%= link_to "削除", decline_job_path(id: job.job.id) %>
+                  </div>
+                <% else %> <span class = "st__my__main__keepca__detail__table__tr__td__action__ca">生徒のみ表示</span>
+                <% end %>
+              </td>
+              </tr>
             <% end %>
-          </table>
-        </div>
-      </section>
-    <% end %>
+          <% end %>
+        </table>
+      </div>
+    </section>
   </div>
 </main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,8 @@ Rails.application.routes.draw do
     get 'all', to: 'jobs#all', on: :collection   #job一覧ページ
     get 'keep', to: 'jobs#keep', on: :member     #jobの選考状況を検討中へ変更(生徒のmyページにて)
     get 'apply', to: 'jobs#apply', on: :member   #jobの選考状況を応募へ変更(生徒のmyページにて)
+    get 'consider', to: 'jobs#consider', on: :member   #jobの選考状況を検討中へ変更(生徒のmyページにて)
+    get 'decline', to: 'jobs#decline', on: :member   #jobの選考状況を検討中へ変更(生徒のmyページにて)
     get 'change', to: 'jobs#change', on: :member #jobの選考状況を変更(求人詳細にて)
     get 'state', to: 'jobs#state', on: :member   #jobの応募状況を変更(求人詳細にて)
   end


### PR DESCRIPTION
# what
生徒のマイページにて検討中のものは「応募」もしくは「検討中止」に求人を移動できる
生徒のマイページにてCA推薦中のものは「応募」、「検討」、もしくは「削除（辞退）」を選択できるようにした

# why
当初の予定ではトップページにCA推薦中の企業を一覧する予定だったが、変更となったため、生徒のマイページでCA推薦中の企業も表示する必要があるため